### PR TITLE
chore: add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners are the maintainers and approvers of this repo
+*       @dapr/maintainers-python-sdk @dapr/approvers-python-sdk


### PR DESCRIPTION
This PR adds CODEOWNERS file since these durabletask is a natural extension of the SDK and should follow the same ownership.