### PR TITLE
fix: fail activity/orchestrator immediately when gRPC result exceeds max message size

### DIFF
--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from threading import Event, Thread
 from types import GeneratorType
-from typing import Any, Generator, Iterator, Optional, Sequence, TypeVar
+from typing import Any, Generator, Iterator, Optional, Sequence, TypeVar, Union
 
 import grpc
 from google.protobuf import empty_pb2
@@ -30,8 +30,7 @@ TOutput = TypeVar("TOutput")
 # If `opentelemetry-sdk` is available, enable the tracer
 try:
     from opentelemetry import trace
-    from opentelemetry.trace.propagation.tracecontext import \
-        TraceContextTextMapPropagator
+    from opentelemetry.trace.propagation.tracecontext TraceContextTextMapPropagator
 
     otel_propagator = TraceContextTextMapPropagator()
     otel_tracer = trace.get_tracer(__name__)

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -31,7 +31,7 @@ TOutput = TypeVar("TOutput")
 # If `opentelemetry-sdk` is available, enable the tracer
 try:
     from opentelemetry import trace
-    from opentelemetry.trace.propagation.tracecontext TraceContextTextMapPropagator
+    from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
     otel_propagator = TraceContextTextMapPropagator()
     otel_tracer = trace.get_tracer(__name__)
@@ -207,9 +207,13 @@ def _is_message_too_large(rpc_error: grpc.RpcError) -> bool:
     RESOURCE_EXHAUSTED is also used for rate limiting / quota errors, which are transient and
     should not be treated the same as a permanent message-size violation.
     """
+    if rpc_error.code() != grpc.StatusCode.RESOURCE_EXHAUSTED:
+        return False
+    details = (rpc_error.details() or "").lower()
     return (
-        rpc_error.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
-        and "received message larger than max" in (rpc_error.details() or "").lower()
+        "message larger than max" in details
+        or "received message larger than max" in details
+        or "sent message larger than max" in details
     )
 
 

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -202,19 +202,12 @@ class ActivityNotRegisteredError(ValueError):
 
 
 def _is_message_too_large(rpc_error: grpc.RpcError) -> bool:
-    """Return True if a RESOURCE_EXHAUSTED error is due to a message exceeding the gRPC size limit.
+    """Return True if the gRPC error is RESOURCE_EXHAUSTED.
 
-    RESOURCE_EXHAUSTED is also used for rate limiting / quota errors, which are transient and
-    should not be treated the same as a permanent message-size violation.
+    All RESOURCE_EXHAUSTED errors are treated as a permanent message-size violation
+    so the sidecar always receives an acknowledgment and avoids infinite redelivery.
     """
-    if rpc_error.code() != grpc.StatusCode.RESOURCE_EXHAUSTED:
-        return False
-    details = (rpc_error.details() or "").lower()
-    return (
-        "message larger than max" in details
-        or "received message larger than max" in details
-        or "sent message larger than max" in details
-    )
+    return rpc_error.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
 
 
 # TODO: refactor this to closely match durabletask-go/client/worker_grpc.go instead of this.

--- a/durabletask/worker.py
+++ b/durabletask/worker.py
@@ -201,6 +201,18 @@ class ActivityNotRegisteredError(ValueError):
     pass
 
 
+def _is_message_too_large(rpc_error: grpc.RpcError) -> bool:
+    """Return True if a RESOURCE_EXHAUSTED error is due to a message exceeding the gRPC size limit.
+
+    RESOURCE_EXHAUSTED is also used for rate limiting / quota errors, which are transient and
+    should not be treated the same as a permanent message-size violation.
+    """
+    return (
+        rpc_error.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+        and "received message larger than max" in (rpc_error.details() or "").lower()
+    )
+
+
 # TODO: refactor this to closely match durabletask-go/client/worker_grpc.go instead of this.
 class TaskHubGrpcWorker:
     """A gRPC-based worker for processing durable task orchestrations and activities.
@@ -841,7 +853,34 @@ class TaskHubGrpcWorker:
         try:
             stub.CompleteOrchestratorTask(res)
         except grpc.RpcError as rpc_error:  # type: ignore
-            self._handle_grpc_execution_error(rpc_error, "orchestrator")
+            if _is_message_too_large(rpc_error):
+                # Response is too large to deliver - fail the orchestration immediately.
+                # This can only be fixed with infrastructure changes (increasing gRPC max message size).
+                self._logger.error(
+                    f"Orchestrator response for '{req.instanceId}' is too large to deliver "
+                    f"(RESOURCE_EXHAUSTED). Failing the orchestration task: {rpc_error.details()}"
+                )
+                failure_actions = [
+                    ph.new_complete_orchestration_action(
+                        -1, pb.ORCHESTRATION_STATUS_FAILED, "",
+                        ph.new_failure_details(RuntimeError(
+                            f"Orchestrator response exceeds gRPC max message size: {rpc_error.details()}"
+                        ))
+                    )
+                ]
+                failure_res = pb.OrchestratorResponse(
+                    instanceId=req.instanceId,
+                    actions=failure_actions,
+                    completionToken=completionToken,
+                )
+                try:
+                    stub.CompleteOrchestratorTask(failure_res)
+                except Exception as ex:
+                    self._logger.exception(
+                        f"Failed to deliver orchestrator failure response for '{req.instanceId}': {ex}"
+                    )
+            else:
+                self._handle_grpc_execution_error(rpc_error, "orchestrator")
         except Exception as ex:
             self._logger.exception(
                 f"Failed to deliver orchestrator response for '{req.instanceId}' to sidecar: {ex}"
@@ -889,7 +928,30 @@ class TaskHubGrpcWorker:
             try:
                 stub.CompleteActivityTask(res)
             except grpc.RpcError as rpc_error:  # type: ignore
-                self._handle_grpc_execution_error(rpc_error, "activity")
+                if _is_message_too_large(rpc_error):
+                    # Result is too large to deliver - fail the activity immediately.
+                    # This can only be fixed with infrastructure changes (increasing gRPC max message size).
+                    self._logger.error(
+                        f"Activity '{req.name}#{req.taskId}' result is too large to deliver "
+                        f"(RESOURCE_EXHAUSTED). Failing the activity task: {rpc_error.details()}"
+                    )
+                    failure_res = pb.ActivityResponse(
+                        instanceId=instance_id,
+                        taskId=req.taskId,
+                        failureDetails=ph.new_failure_details(RuntimeError(
+                            f"Activity result exceeds gRPC max message size: {rpc_error.details()}"
+                        )),
+                        completionToken=completionToken,
+                    )
+                    try:
+                        stub.CompleteActivityTask(failure_res)
+                    except Exception as ex:
+                        self._logger.exception(
+                            f"Failed to deliver activity failure response for '{req.name}#{req.taskId}' "
+                            f"of orchestration ID '{instance_id}': {ex}"
+                        )
+                else:
+                    self._handle_grpc_execution_error(rpc_error, "activity")
             except Exception as ex:
                 self._logger.exception(
                     f"Failed to deliver activity response for '{req.name}#{req.taskId}' of orchestration ID '{instance_id}' to sidecar: {ex}"

--- a/tests/durabletask/test_registry.py
+++ b/tests/durabletask/test_registry.py
@@ -165,6 +165,7 @@ def test_registry_add_multiple_activities():
     assert registry.get_activity(name1) is activity1
     assert registry.get_activity(name2) is activity2
 
+
 def test_registry_add_named_versioned_orchestrators():
     """Test adding versioned orchestrators."""
     registry = worker._Registry()
@@ -179,7 +180,9 @@ def test_registry_add_named_versioned_orchestrators():
         return "two"
 
     registry.add_named_orchestrator(name="orchestrator", fn=orchestrator1, version_name="v1")
-    registry.add_named_orchestrator(name="orchestrator", fn=orchestrator2, version_name="v2", is_latest=True)
+    registry.add_named_orchestrator(
+        name="orchestrator", fn=orchestrator2, version_name="v2", is_latest=True
+    )
     registry.add_named_orchestrator(name="orchestrator", fn=orchestrator3, version_name="v3")
 
     orquestrator, version = registry.get_orchestrator(name="orchestrator")


### PR DESCRIPTION
Before, when an activity/orchestrator returned a result too large to deliver over gRPC, then `CompleteActivityTask` and/or `CompleteOrchestratorTask` raised `RESOURCE_EXHAUSTED`. This fell through and got logged, but the sidecar never received an acknowledgement and would redeliver the same work item repeatedly, causing an infinite failure loop with noisy and confusing logs.

This PR captures this error, sending the failure response back to the sidecar with a clear error message and surfaces the proper task failure rather than silently hanging.

I've left all other types of `RESOURCE_EXHAUSTED` errors alone, as this one for sure is a permanent error regarding message size violations and require some sort of infra change to increase `grpc.max_send_message_length` on the sidecar to fix it properly.